### PR TITLE
Compatibility with Polylang 3.4.3

### DIFF
--- a/polylang-translated-table-example.php
+++ b/polylang-translated-table-example.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Polylang translated table example
  * Plugin URI:        https://polylang.pro
  * Description:       Example plugin that creates translated a custom DB table.
- * Version:           1.0
+ * Version:           1.1
  * Requires at least: 5.8
  * Requires PHP:      5.6
  * Author:            WP SYNTEX

--- a/polylang-translated-table-example.php
+++ b/polylang-translated-table-example.php
@@ -9,7 +9,7 @@
  * @wordpress-plugin
  * Plugin Name:       Polylang translated table example
  * Plugin URI:        https://polylang.pro
- * Description:       Example plugin that creates translated a custom DB table.
+ * Description:       Example plugin that creates translated a custom DB table. Requires Polylang 3.4.3.
  * Version:           1.1
  * Requires at least: 5.8
  * Requires PHP:      5.6
@@ -52,6 +52,11 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 add_action(
 	'pll_model_init',
 	function ( $model ) {
+		if ( version_compare( POLYLANG_VERSION, '3.4.3', '<' ) ) {
+			// Polylang 3.4.3 is required.
+			return;
+		}
+
 		// Register the DB table in Polylang.
 		$translatedEvents = ( new TranslatedEvents( $model ) )->init();
 		$model->translatable_objects->register( $translatedEvents );

--- a/src/TranslatedEvents.php
+++ b/src/TranslatedEvents.php
@@ -65,11 +65,6 @@ class TranslatedEvents extends \PLL_Translated_Object implements \PLL_Translatab
 	public function __construct( \PLL_Model $model ) {
 		$this->cache_type = Query::CACHE_GROUP;
 
-		if ( property_exists( $this, 'db' ) ) {
-			// Backward compatibility with Polylang < 3.4.3.
-			$this->db = $this->get_db_infos();
-		}
-
 		parent::__construct( $model );
 	}
 


### PR DESCRIPTION
This PR fixes the issue where, since PLL 3.4.3, the info related to the DB are returned by `PLL_Translated_Object::get_db_infos()` instead of being stored in `PLL_Translated_Object::$db`. This was causing a fatal error because of the abstract method not being implemented.

Backward compatibility with the `$db` property is assured.

This PR also bumps the plugin's version to 1.1.